### PR TITLE
Fix Hovertext for 1D

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 ### API
 
+- Fix hover-text for 1D arrays (#58)
 - Allow `int` dtype for `DPArray` (#53)
 - Self-testing mode perists over multiple timesteps (#43)
 - Add annotation functionality (#36, #50)

--- a/dp/_visualizer.py
+++ b/dp/_visualizer.py
@@ -162,8 +162,7 @@ class Visualizer:
 
         logger = self._graph_metadata[self._primary]["arr"].logger
         if logger is not arr.logger:
-            raise ValueError("Added arrays should have the same"
-                             "logger")
+            raise ValueError("Added arrays should have the same" "logger")
 
     def _parse_timesteps(self, arr):
         """Parse the timesteps of the logger."""
@@ -330,6 +329,11 @@ class Visualizer:
                 },
             })
 
+        hovertemplate = "<b>%{y}, %{x}</b>%{customdata}<extra></extra>"
+        if h == 1:
+            hovertemplate = "<b>%{x}</b>%{customdata}<extra></extra>"
+        if w == 1:
+            hovertemplate = "<b>%{y}</b>%{customdata}<extra></extra>"
         for color, val, extra in zip(t_color_matrix, value_text,
                                      extra_hovertext):
             figure.add_heatmap(
@@ -338,7 +342,7 @@ class Visualizer:
                 texttemplate="%{text}",
                 textfont={"size": 20},
                 customdata=extra,
-                hovertemplate="<b>%{y}, %{x}</b>%{customdata}<extra></extra>",
+                hovertemplate=hovertemplate,
                 **_get_colorbar_kwargs(colorscale_name),
                 xgap=1,
                 ygap=1,
@@ -634,10 +638,10 @@ class Visualizer:
             # Updates test info, the alert, and resets clickData.
             return info, correct_alert, None, dash.no_update
 
-        @self.app.callback(
-            Output(self._primary, "figure", allow_duplicate=True),
-            Input(self._primary, "clickData"), State("test-info", "data"),
-            State("slider", "value"))
+        @self.app.callback(Output(self._primary, "figure",
+                                  allow_duplicate=True),
+                           Input(self._primary, "clickData"),
+                           State("test-info", "data"), State("slider", "value"))
         def display_dependencies(click_data, info, t):
             # Skip this callback in testing mode.
             if info["tests"] or not click_data:

--- a/dp/_visualizer.py
+++ b/dp/_visualizer.py
@@ -728,7 +728,7 @@ class Visualizer:
             dbc.Stack([
                 *description_md,
                 test_select_checkbox,
-                dbc.Input(id="user-input", type="number", placeholder=""),
+                dbc.Input(id="user-input", type="number", placeholder="Enter value here"),
                 dbc.Card([], id="array-annotation", color="info", outline=True),
             ],
                       id="sidebar"),

--- a/dp/_visualizer.py
+++ b/dp/_visualizer.py
@@ -162,7 +162,7 @@ class Visualizer:
 
         logger = self._graph_metadata[self._primary]["arr"].logger
         if logger is not arr.logger:
-            raise ValueError("Added arrays should have the same" "logger")
+            raise ValueError("Added arrays should have the same logger")
 
     def _parse_timesteps(self, arr):
         """Parse the timesteps of the logger."""


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->
Only shows hover text for x or y if the array is 1D (either height = 1 or width = 1).

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/itsdawei/dynamically_programmed/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have linted my code with `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
