### PR TITLE
docs: fix image path

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
 ### Examples
 
-- Add edit distance (#49, #66)
+- Add edit distance (#49, #66, #71)
 - Add weighted interval scheduling (#53, #69)
 
 ### API

--- a/docs/examples/wis.ipynb
+++ b/docs/examples/wis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "423585e9",
+   "id": "6aad4226",
    "metadata": {},
    "source": [
     "# Weighted Interval Scheduling\n",
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "d511a1ed",
+   "id": "c91015ef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92ed0636",
+   "id": "609cd5c5",
    "metadata": {},
    "source": [
     "## Dynamic Programming Solution\n",
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9cbc2286",
+   "id": "380eeec5",
    "metadata": {},
    "source": [
     "## Implementation\n",
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ab5c3054",
+   "id": "6398ce45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cd6b58a",
+   "id": "131ad748",
    "metadata": {},
    "source": [
     "Then, create an empty array $OPT$, where $OPT[i]$ stores the optimal value consisting of the first $i$ intervals."
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "f92bc06a",
+   "id": "025dada7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "639fd777",
+   "id": "4dcb7c43",
    "metadata": {},
    "source": [
     "When we include interval $i$, we need to determine which intervals are no longer available. To do this, we will precompute an array $p$, where **$p[i]$ denotes the largest index $j < i$ s.t. interval $i$ is compatible with $j$**."
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "fb2cddde",
+   "id": "dd1f8c1e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc82f84d",
+   "id": "d7fc20cf",
    "metadata": {},
    "source": [
     "There are a few interesting things going in this code:\n",
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91f4c1cb",
+   "id": "ebdd5279",
    "metadata": {},
    "source": [
     "Now we are ready to implement the dynamic program, which is just the optimal substructure that we derived earlier."
@@ -150,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "34bd5871",
+   "id": "30f184b6",
    "metadata": {},
    "outputs": [
     {
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14c54e65",
+   "id": "b0e3e20c",
    "metadata": {},
    "source": [
     "## Visualization with `dpvis`\n",
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "5600088d",
+   "id": "7fed8fa1",
    "metadata": {},
    "outputs": [
     {
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b2a6c21",
+   "id": "94e61e9a",
    "metadata": {},
    "source": [
     "Optionally, you may add additional information to the visualization. For example, the column labels"
@@ -231,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c3a8d8a4",
+   "id": "29164e06",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06743b34",
+   "id": "e3860457",
    "metadata": {},
    "source": [
     "To render the visualization, use the `display` function."
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "27bb5b10",
+   "id": "142c01e2",
    "metadata": {
     "tags": [
      "hide_output"
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21d6deef",
+   "id": "b947b2d5",
    "metadata": {},
    "source": [
     "After executing the code above, this is what you will see when you go to [https://127.0.0.1:8050](https://127.0.0.1:8050).\n",
@@ -308,14 +308,6 @@
     "max(a[2] + OPT[p[i]], OPT[i - 1])\n",
     "```"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22d0e7fc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/examples/wis.ipynb
+++ b/docs/examples/wis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "aa21f104",
+   "id": "423585e9",
    "metadata": {},
    "source": [
     "# Weighted Interval Scheduling\n",
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "308c10e9",
+   "id": "d511a1ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ae91855",
+   "id": "92ed0636",
    "metadata": {},
    "source": [
     "## Dynamic Programming Solution\n",
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b934266",
+   "id": "9cbc2286",
    "metadata": {},
    "source": [
     "## Implementation\n",
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "75d3799c",
+   "id": "ab5c3054",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0ebf1ff",
+   "id": "4cd6b58a",
    "metadata": {},
    "source": [
     "Then, create an empty array $OPT$, where $OPT[i]$ stores the optimal value consisting of the first $i$ intervals."
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "f6296c21",
+   "id": "f92bc06a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "889b9e2d",
+   "id": "639fd777",
    "metadata": {},
    "source": [
     "When we include interval $i$, we need to determine which intervals are no longer available. To do this, we will precompute an array $p$, where **$p[i]$ denotes the largest index $j < i$ s.t. interval $i$ is compatible with $j$**."
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "0858a116",
+   "id": "fb2cddde",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12fbec0d",
+   "id": "dc82f84d",
    "metadata": {},
    "source": [
     "There are a few interesting things going in this code:\n",
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3c8386a",
+   "id": "91f4c1cb",
    "metadata": {},
    "source": [
     "Now we are ready to implement the dynamic program, which is just the optimal substructure that we derived earlier."
@@ -150,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "e4545d09",
+   "id": "34bd5871",
    "metadata": {},
    "outputs": [
     {
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de3b692d",
+   "id": "14c54e65",
    "metadata": {},
    "source": [
     "## Visualization with `dpvis`\n",
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "eed41200",
+   "id": "5600088d",
    "metadata": {},
    "outputs": [
     {
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5aa9a8fa",
+   "id": "1b2a6c21",
    "metadata": {},
    "source": [
     "Optionally, you may add additional information to the visualization. For example, the column labels"
@@ -231,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "7365c548",
+   "id": "c3a8d8a4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4eae7360",
+   "id": "06743b34",
    "metadata": {},
    "source": [
     "To render the visualization, use the `display` function."
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "bde399b8",
+   "id": "27bb5b10",
    "metadata": {
     "tags": [
      "hide_output"
@@ -285,12 +285,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "631a9d81",
+   "id": "21d6deef",
    "metadata": {},
    "source": [
     "After executing the code above, this is what you will see when you go to [https://127.0.0.1:8050](https://127.0.0.1:8050).\n",
     "\n",
-    "<img src=\"../_assets/imgs/wis_t0.png\" width=\"75%\"/>\n",
+    "<img src=\"../../_assets/imgs/wis_t0.png\" width=\"75%\"/>\n",
     "\n",
     "- On the top of the page is a slider to control what timestep is being visualized.\n",
     "- The slider can be used to show different timesteps by clicking and dragging or using the <span style=\"color:white;background-color:black\">PLAY</span> and <span style=\"color:white;background-color:black\">STOP</span> buttons.\n",
@@ -299,7 +299,7 @@
     "\n",
     "Try dragging the slider to timestep 5.\n",
     "\n",
-    "<img src=\"../_assets/imgs/wis_t5.png\" width=\"75%\"/>\n",
+    "<img src=\"../../_assets/imgs/wis_t5.png\" width=\"75%\"/>\n",
     "\n",
     "Now the visual shows the array with the first six elements set. On this timestep, elements two and four of the `OPT` array are <span style=\"background-color:#b7609a\">READ</span>, meaning we accessed the values of those elements on this timestep. We also <span style=\"background-color:#5c53a5\">WRITE</span> a value of `5` to element five of the `OPT` array. This corresponds to line 37 in our code when `i=5`:\n",
     "\n",
@@ -312,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b38713e",
+   "id": "22d0e7fc",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/examples/wis.ipynb
+++ b/docs/examples/wis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "854cd794",
+   "id": "aa21f104",
    "metadata": {},
    "source": [
     "# Weighted Interval Scheduling\n",
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "394aeefc",
+   "id": "308c10e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51ab3c10",
+   "id": "3ae91855",
    "metadata": {},
    "source": [
     "## Dynamic Programming Solution\n",
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6e6d717",
+   "id": "5b934266",
    "metadata": {},
    "source": [
     "## Implementation\n",
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e42e0f66",
+   "id": "75d3799c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65f53a10",
+   "id": "e0ebf1ff",
    "metadata": {},
    "source": [
     "Then, create an empty array $OPT$, where $OPT[i]$ stores the optimal value consisting of the first $i$ intervals."
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a4374989",
+   "id": "f6296c21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46e0901c",
+   "id": "889b9e2d",
    "metadata": {},
    "source": [
     "When we include interval $i$, we need to determine which intervals are no longer available. To do this, we will precompute an array $p$, where **$p[i]$ denotes the largest index $j < i$ s.t. interval $i$ is compatible with $j$**."
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9da4c90d",
+   "id": "0858a116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ae3b93c",
+   "id": "12fbec0d",
    "metadata": {},
    "source": [
     "There are a few interesting things going in this code:\n",
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5f2f471",
+   "id": "e3c8386a",
    "metadata": {},
    "source": [
     "Now we are ready to implement the dynamic program, which is just the optimal substructure that we derived earlier."
@@ -150,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "9348cb1b",
+   "id": "e4545d09",
    "metadata": {},
    "outputs": [
     {
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2920a03a",
+   "id": "de3b692d",
    "metadata": {},
    "source": [
     "## Visualization with `dpvis`\n",
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "fee860d1",
+   "id": "eed41200",
    "metadata": {},
    "outputs": [
     {
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7129da6",
+   "id": "5aa9a8fa",
    "metadata": {},
    "source": [
     "Optionally, you may add additional information to the visualization. For example, the column labels"
@@ -231,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "705f249d",
+   "id": "7365c548",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "762c7848",
+   "id": "4eae7360",
    "metadata": {},
    "source": [
     "To render the visualization, use the `display` function."
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "cef40f09",
+   "id": "bde399b8",
    "metadata": {
     "tags": [
      "hide_output"
@@ -285,12 +285,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52a06deb",
+   "id": "631a9d81",
    "metadata": {},
    "source": [
     "After executing the code above, this is what you will see when you go to [https://127.0.0.1:8050](https://127.0.0.1:8050).\n",
     "\n",
-    "<img src=\"/_assets/imgs/wis_t0.png\" width=\"75%\"/>\n",
+    "<img src=\"../_assets/imgs/wis_t0.png\" width=\"75%\"/>\n",
     "\n",
     "- On the top of the page is a slider to control what timestep is being visualized.\n",
     "- The slider can be used to show different timesteps by clicking and dragging or using the <span style=\"color:white;background-color:black\">PLAY</span> and <span style=\"color:white;background-color:black\">STOP</span> buttons.\n",
@@ -299,7 +299,7 @@
     "\n",
     "Try dragging the slider to timestep 5.\n",
     "\n",
-    "<img src=\"/_assets/imgs/wis_t5.png\" width=\"75%\"/>\n",
+    "<img src=\"../_assets/imgs/wis_t5.png\" width=\"75%\"/>\n",
     "\n",
     "Now the visual shows the array with the first six elements set. On this timestep, elements two and four of the `OPT` array are <span style=\"background-color:#b7609a\">READ</span>, meaning we accessed the values of those elements on this timestep. We also <span style=\"background-color:#5c53a5\">WRITE</span> a value of `5` to element five of the `OPT` array. This corresponds to line 37 in our code when `i=5`:\n",
     "\n",
@@ -308,6 +308,14 @@
     "max(a[2] + OPT[p[i]], OPT[i - 1])\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b38713e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the PR's purpose here. -->
#69 introduced a bug where the image path is not rendered on the jupyter notebook.

The problem is that the images references the path https://dpvis.readthedocs.io/_assets/imgs/wis_t5.png while it should be https://dpvis.readthedocs.io/en/latest/_assets/imgs/wis_t5.png.

The problem can be solve by using relative path in specifying the image path. For example, instead of `_assets/imgs/wis_t0.png`, we should use `../../_assets/imgs/wis_t0.png`. This is be cause the url for the example is https://dpvis.readthedocs.io/en/latest/examples/wis/, so we want to go two levels back to access the `_assets` directory.

## TODO

<!-- Notable points that this PR has either accomplished or will accomplish. -->

- [x] Fix it

## Status

- [x] I have read the guidelines in [CONTRIBUTING.md](https://github.com/itsdawei/dynamically_programmed/blob/master/CONTRIBUTING.md)
- [x] I have formatted my code using `yapf`
- [x] I have linted my code with `pylint`
- [x] I have tested my code by running `pytest`
- [x] I have added a one-line description of my change to the changelog in `HISTORY.md`
- [x] This PR is ready to go
